### PR TITLE
"Resolving" issue with static display of images in markdown cells.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -239,6 +239,9 @@ all of the required data:
 <li>[5:15PM - 5:30PM] notebook development and testing, concluding remarks. [ppt: <a href="simpleitkNotebookDevelopmentTesting.pptx">development and testing </a>]</li>
 </ul>
 
+* You will have to run the <code>jupyter notebook</code> command in the main directory of the repository, otherwise the static images shared by the Python and R
+notebooks are not displayed (<a href="https://github.com/jupyter/notebook/issues/230">this is a feature not a bug</a>).
+
 <a id="program"></a><h3>Supplementary Material</h3>
 
 <p>


### PR DESCRIPTION
Images were not displayed if the jupyter notebook server is started in
the python or r directories, with the images one directory above. This
is a feature and not a bug in the jupyter notebook app
(https://github.com/jupyter/notebook/issues/230).